### PR TITLE
feat: add endorsement metrics

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,8 +6,8 @@ export const countNearTokens = (yoctoNear) =>
 
 export const countProductivity = (validatorState) => {
   const productivityInfo =
-    (validatorState?.num_produced_blocks + validatorState?.num_produced_chunks) /
-    (validatorState?.num_expected_blocks + validatorState?.num_expected_chunks);
+    (validatorState?.num_produced_blocks + validatorState?.num_produced_chunks + validatorState?.num_produced_endorsements) /
+    (validatorState?.num_expected_blocks + validatorState?.num_expected_chunks + validatorState?.num_expected_endorsements);
 
   const productivity = productivityInfo
     ? Math.floor(productivityInfo * 10000) / 100
@@ -30,6 +30,11 @@ export const getChunksBlocksStat = (tableName = "", validatorState = {}) => {
       "Chunks",
       validatorState.num_expected_chunks,
       validatorState.num_produced_chunks
+    )
+    .addRow(
+      "Endorsements",
+      validatorState.num_expected_endorsements,
+      validatorState.num_produced_endorsements
     );
 
   return [


### PR DESCRIPTION
https://github.com/near/nearcore/releases/tag/2.0.0

Non-top 100 Validator are no longer producing chunks, they validate chunks instead. The metrics for monitoring it are `num_produced_endorsements` and `num_expected_endorsements`. Here's a sample response from `{method: "validators"}`.

![image](https://github.com/user-attachments/assets/8c2844be-cd5c-4f5f-82a4-2d7014d5c74c)

The table in telegram now looks like this (I just console.log in terminal for convenient)
![image](https://github.com/user-attachments/assets/21b44baf-eb6e-421a-ac03-3c71d102f81c)
